### PR TITLE
feat: add Unity editor integration for Context7

### DIFF
--- a/UnityContext7Assistant/Assets/Editor/Context7ApiClient.cs
+++ b/UnityContext7Assistant/Assets/Editor/Context7ApiClient.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace BlazeIntelligence.Context7
+{
+    internal static class Context7ApiClient
+    {
+        private const string DefaultBaseUrl = "https://context7.com/api";
+
+        public static async Task<Context7SearchResponse> SearchAsync(
+            string query,
+            string? apiKey,
+            string? clientIp,
+            string? baseUrl,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return new Context7SearchResponse
+                {
+                    Error = "Query cannot be empty.",
+                };
+            }
+
+            var requestUrl = BuildUrl(baseUrl, $"/v1/search?query={UnityWebRequest.EscapeURL(query)}");
+            using var request = UnityWebRequest.Get(requestUrl);
+            ApplyCommonHeaders(request, apiKey, clientIp);
+
+            return await SendAndParseAsync<Context7SearchResponse>(request, cancellationToken);
+        }
+
+        public static async Task<string> FetchDocumentationAsync(
+            string libraryId,
+            int tokens,
+            string? topic,
+            string? apiKey,
+            string? clientIp,
+            string? baseUrl,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(libraryId))
+            {
+                return "Select a library from the search results first.";
+            }
+
+            var builder = new StringBuilder();
+            builder.Append($"/v1/{libraryId.TrimStart('/')}");
+            var hasQuery = false;
+
+            if (tokens > 0)
+            {
+                builder.Append(hasQuery ? "&" : "?");
+                builder.Append($"tokens={Mathf.Clamp(tokens, 500, 10000)}");
+                hasQuery = true;
+            }
+
+            builder.Append(hasQuery ? "&" : "?");
+            builder.Append("type=txt");
+            hasQuery = true;
+
+            if (!string.IsNullOrWhiteSpace(topic))
+            {
+                builder.Append(hasQuery ? "&" : "?");
+                builder.Append($"topic={UnityWebRequest.EscapeURL(topic)}");
+            }
+
+            var requestUrl = BuildUrl(baseUrl, builder.ToString());
+            using var request = UnityWebRequest.Get(requestUrl);
+            ApplyCommonHeaders(request, apiKey, clientIp, ("X-Context7-Source", "unity-editor"));
+
+            return await SendTextAsync(request, cancellationToken);
+        }
+
+        private static string BuildUrl(string? baseUrl, string pathAndQuery)
+        {
+            var root = string.IsNullOrWhiteSpace(baseUrl) ? DefaultBaseUrl : baseUrl.TrimEnd('/');
+            return root + pathAndQuery;
+        }
+
+        private static void ApplyCommonHeaders(
+            UnityWebRequest request,
+            string? apiKey,
+            string? clientIp,
+            params (string Key, string Value)[] extraHeaders)
+        {
+            request.SetRequestHeader("Accept", "application/json");
+            foreach (var (key, value) in extraHeaders)
+            {
+                request.SetRequestHeader(key, value);
+            }
+
+            if (!string.IsNullOrWhiteSpace(clientIp))
+            {
+                request.SetRequestHeader("mcp-client-ip", clientIp);
+            }
+
+            if (!string.IsNullOrWhiteSpace(apiKey))
+            {
+                request.SetRequestHeader("Authorization", $"Bearer {apiKey}");
+            }
+        }
+
+        private static async Task<T> SendAndParseAsync<T>(UnityWebRequest request, CancellationToken cancellationToken)
+            where T : new()
+        {
+            var json = await SendTextAsync(request, cancellationToken);
+            if (string.IsNullOrEmpty(json))
+            {
+                return new T();
+            }
+
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(json) ?? new T();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[Context7] Failed to parse response: {ex.Message}\nRaw: {json}");
+                return new T();
+            }
+        }
+
+        private static async Task<string> SendTextAsync(UnityWebRequest request, CancellationToken cancellationToken)
+        {
+            request.downloadHandler = new DownloadHandlerBuffer();
+
+            var operation = request.SendWebRequest();
+            while (!operation.isDone)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    request.Abort();
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                await Task.Yield();
+            }
+
+            if (request.result == UnityWebRequest.Result.ConnectionError ||
+                request.result == UnityWebRequest.Result.DataProcessingError)
+            {
+                throw new InvalidOperationException($"Context7 request failed: {request.error}");
+            }
+
+            if (request.result == UnityWebRequest.Result.ProtocolError)
+            {
+                var payload = request.downloadHandler.text;
+                throw new InvalidOperationException(
+                    $"Context7 returned {(int)request.responseCode}: {request.error}\n{payload}");
+            }
+
+            return request.downloadHandler.text;
+        }
+    }
+}

--- a/UnityContext7Assistant/Assets/Editor/Context7AssistantWindow.cs
+++ b/UnityContext7Assistant/Assets/Editor/Context7AssistantWindow.cs
@@ -1,0 +1,329 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace BlazeIntelligence.Context7
+{
+    public sealed class Context7AssistantWindow : EditorWindow
+    {
+        private string _query = string.Empty;
+        private readonly List<Context7SearchResult> _results = new();
+        private Context7SearchResult? _selectedResult;
+        private string _documentation = string.Empty;
+        private bool _isSearching;
+        private bool _isFetchingDocumentation;
+        private string? _errorMessage;
+        private int _tokenBudget = 3000;
+        private string _topicFilter = string.Empty;
+        private string _apiKeyInput = string.Empty;
+        private string _clientIp = string.Empty;
+        private string _baseUrl = string.Empty;
+        private Vector2 _resultsScroll;
+        private Vector2 _documentationScroll;
+        private CancellationTokenSource? _requestCts;
+
+        [MenuItem("Blaze Intelligence/Context7 Assistant")]
+        private static void Open()
+        {
+            var window = GetWindow<Context7AssistantWindow>(utility: false, title: "Context7 Assistant");
+            window.minSize = new Vector2(640, 480);
+            window.Show();
+        }
+
+        private void OnEnable()
+        {
+            _baseUrl = EditorPrefs.GetString("Context7.BaseUrl", "https://context7.com/api");
+            _tokenBudget = EditorPrefs.GetInt("Context7.DefaultTokens", 3000);
+            _topicFilter = EditorPrefs.GetString("Context7.LastTopic", string.Empty);
+            _clientIp = Environment.GetEnvironmentVariable("CONTEXT7_CLIENT_IP") ?? string.Empty;
+            var envApiKey = Environment.GetEnvironmentVariable("CONTEXT7_API_KEY");
+            _apiKeyInput = string.IsNullOrWhiteSpace(envApiKey) ? string.Empty : envApiKey!;
+        }
+
+        private void OnDisable()
+        {
+            _requestCts?.Cancel();
+            _requestCts?.Dispose();
+            EditorPrefs.SetString("Context7.BaseUrl", _baseUrl);
+            EditorPrefs.SetInt("Context7.DefaultTokens", _tokenBudget);
+            EditorPrefs.SetString("Context7.LastTopic", _topicFilter);
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.LabelField("Context7 Unity Assistant", EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox(
+                "Query Context7 for up-to-date documentation and code examples without leaving the Unity Editor.",
+                MessageType.Info);
+
+            DrawConfiguration();
+            DrawSearchArea();
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                DrawResultsList();
+                DrawDocumentationPanel();
+            }
+        }
+
+        private void DrawConfiguration()
+        {
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Configuration", EditorStyles.boldLabel);
+
+            EditorGUI.BeginChangeCheck();
+            _baseUrl = EditorGUILayout.TextField("API URL", string.IsNullOrWhiteSpace(_baseUrl) ? "https://context7.com/api" : _baseUrl);
+            if (EditorGUI.EndChangeCheck())
+            {
+                _baseUrl = string.IsNullOrWhiteSpace(_baseUrl) ? "https://context7.com/api" : _baseUrl.TrimEnd('/');
+            }
+
+            _tokenBudget = EditorGUILayout.IntSlider("Token Budget", _tokenBudget, 500, 8000);
+            _topicFilter = EditorGUILayout.TextField("Topic (optional)", _topicFilter);
+
+            EditorGUILayout.Space(4f);
+            EditorGUILayout.LabelField("Session Credentials", EditorStyles.boldLabel);
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                EditorGUILayout.LabelField("API Key", GUILayout.Width(60));
+                using (new EditorGUI.DisabledScope(true))
+                {
+                    EditorGUILayout.LabelField("Loaded from ENV if set (CONTEXT7_API_KEY)");
+                }
+            }
+            _apiKeyInput = EditorGUILayout.PasswordField(_apiKeyInput);
+            _clientIp = EditorGUILayout.TextField("Client IP (optional)", _clientIp);
+        }
+
+        private void DrawSearchArea()
+        {
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Search Libraries", EditorStyles.boldLabel);
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                GUI.enabled = !_isSearching;
+                _query = EditorGUILayout.TextField(_query);
+                if (GUILayout.Button("Search", GUILayout.Width(100)))
+                {
+                    _ = ExecuteSearchAsync();
+                }
+                GUI.enabled = true;
+            }
+
+            if (_errorMessage is { Length: > 0 })
+            {
+                EditorGUILayout.HelpBox(_errorMessage, MessageType.Error);
+            }
+        }
+
+        private void DrawResultsList()
+        {
+            using (new EditorGUILayout.VerticalScope(GUILayout.Width(position.width * 0.35f)))
+            {
+                EditorGUILayout.LabelField("Results", EditorStyles.boldLabel);
+                using (var scroll = new EditorGUILayout.ScrollViewScope(_resultsScroll))
+                {
+                    _resultsScroll = scroll.scrollPosition;
+                    if (_results.Count == 0)
+                    {
+                        EditorGUILayout.LabelField(_isSearching ? "Searching..." : "No results yet. Try a query.");
+                    }
+                    else
+                    {
+                        foreach (var result in _results)
+                        {
+                            DrawResultItem(result);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void DrawResultItem(Context7SearchResult result)
+        {
+            using (new EditorGUILayout.VerticalScope("box"))
+            {
+                var title = string.IsNullOrWhiteSpace(result.Title) ? result.Id : result.Title;
+                var selected = _selectedResult == result;
+                var label = new GUIContent(title, result.Description);
+
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    if (GUILayout.Toggle(selected, label, "Button"))
+                    {
+                        if (!selected)
+                        {
+                            _selectedResult = result;
+                            _ = FetchDocumentationAsync();
+                        }
+                    }
+
+                    if (GUILayout.Button("Copy ID", GUILayout.Width(80)))
+                    {
+                        EditorGUIUtility.systemCopyBuffer = result.Id;
+                        ShowNotification(new GUIContent("Library ID copied."));
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(result.Description))
+                {
+                    EditorGUILayout.LabelField(result.Description, EditorStyles.wordWrappedMiniLabel);
+                }
+
+                EditorGUILayout.LabelField($"Tokens: {result.TotalTokens}  Snippets: {result.TotalSnippets}  Pages: {result.TotalPages}");
+                if (result.TrustScore.HasValue)
+                {
+                    EditorGUILayout.LabelField($"Trust Score: {result.TrustScore:0.00}");
+                }
+                if (result.Versions is { Count: > 0 })
+                {
+                    EditorGUILayout.LabelField("Versions:", string.Join(", ", result.Versions.Take(5)));
+                }
+            }
+        }
+
+        private void DrawDocumentationPanel()
+        {
+            using (new EditorGUILayout.VerticalScope())
+            {
+                EditorGUILayout.LabelField("Documentation", EditorStyles.boldLabel);
+                GUI.enabled = _selectedResult != null && !_isFetchingDocumentation;
+                if (GUILayout.Button("Refresh Context"))
+                {
+                    _ = FetchDocumentationAsync();
+                }
+                GUI.enabled = true;
+
+                using (var scroll = new EditorGUILayout.ScrollViewScope(_documentationScroll))
+                {
+                    _documentationScroll = scroll.scrollPosition;
+                    var content = string.IsNullOrEmpty(_documentation)
+                        ? (_isFetchingDocumentation ? "Fetching documentation..." : "Select a result to load documentation.")
+                        : _documentation;
+                    EditorGUILayout.TextArea(content, GUILayout.ExpandHeight(true));
+                }
+            }
+        }
+
+        private async Task ExecuteSearchAsync()
+        {
+            CancelPendingRequest();
+            _isSearching = true;
+            _errorMessage = null;
+            _results.Clear();
+            _selectedResult = null;
+            _documentation = string.Empty;
+            Repaint();
+
+            _requestCts = new CancellationTokenSource();
+            try
+            {
+                var response = await Context7ApiClient.SearchAsync(
+                    _query,
+                    ResolveApiKey(),
+                    SanitizeClientIp(_clientIp),
+                    _baseUrl,
+                    _requestCts.Token);
+
+                if (!string.IsNullOrWhiteSpace(response.Error))
+                {
+                    _errorMessage = response.Error;
+                }
+
+                _results.AddRange(response.Results);
+                if (_results.Count == 0 && string.IsNullOrEmpty(_errorMessage))
+                {
+                    _errorMessage = "No libraries matched your query.";
+                }
+            }
+            catch (Exception ex)
+            {
+                _errorMessage = ex.Message;
+                Debug.LogError($"[Context7] Search failed: {ex}");
+            }
+            finally
+            {
+                _isSearching = false;
+                _requestCts.Dispose();
+                _requestCts = null;
+                Repaint();
+            }
+        }
+
+        private async Task FetchDocumentationAsync()
+        {
+            if (_selectedResult == null)
+            {
+                return;
+            }
+
+            CancelPendingRequest();
+            _isFetchingDocumentation = true;
+            _documentation = string.Empty;
+            _errorMessage = null;
+            Repaint();
+
+            _requestCts = new CancellationTokenSource();
+            try
+            {
+                var topic = string.IsNullOrWhiteSpace(_topicFilter) ? null : _topicFilter;
+                var text = await Context7ApiClient.FetchDocumentationAsync(
+                    _selectedResult.Id,
+                    _tokenBudget,
+                    topic,
+                    ResolveApiKey(),
+                    SanitizeClientIp(_clientIp),
+                    _baseUrl,
+                    _requestCts.Token);
+                _documentation = text;
+            }
+            catch (Exception ex)
+            {
+                _errorMessage = ex.Message;
+                Debug.LogError($"[Context7] Documentation fetch failed: {ex}");
+            }
+            finally
+            {
+                _isFetchingDocumentation = false;
+                _requestCts.Dispose();
+                _requestCts = null;
+                Repaint();
+            }
+        }
+
+        private void CancelPendingRequest()
+        {
+            if (_requestCts == null)
+            {
+                return;
+            }
+
+            if (!_requestCts.IsCancellationRequested)
+            {
+                _requestCts.Cancel();
+            }
+            _requestCts.Dispose();
+            _requestCts = null;
+        }
+
+        private string? ResolveApiKey()
+        {
+            return string.IsNullOrWhiteSpace(_apiKeyInput) ? null : _apiKeyInput.Trim();
+        }
+
+        private static string? SanitizeClientIp(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            return value.Trim();
+        }
+    }
+}

--- a/UnityContext7Assistant/Assets/Editor/Context7Models.cs
+++ b/UnityContext7Assistant/Assets/Editor/Context7Models.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace BlazeIntelligence.Context7
+{
+    [Serializable]
+    public sealed class Context7SearchResponse
+    {
+        [JsonProperty("error")]
+        public string? Error { get; set; }
+
+        [JsonProperty("results")]
+        public List<Context7SearchResult> Results { get; set; } = new();
+    }
+
+    [Serializable]
+    public sealed class Context7SearchResult
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonProperty("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [JsonProperty("description")]
+        public string Description { get; set; } = string.Empty;
+
+        [JsonProperty("branch")]
+        public string Branch { get; set; } = string.Empty;
+
+        [JsonProperty("lastUpdateDate")]
+        public string LastUpdateDate { get; set; } = string.Empty;
+
+        [JsonProperty("state")]
+        public string State { get; set; } = string.Empty;
+
+        [JsonProperty("totalTokens")]
+        public int TotalTokens { get; set; }
+
+        [JsonProperty("totalSnippets")]
+        public int TotalSnippets { get; set; }
+
+        [JsonProperty("totalPages")]
+        public int TotalPages { get; set; }
+
+        [JsonProperty("stars")]
+        public int? Stars { get; set; }
+
+        [JsonProperty("trustScore")]
+        public double? TrustScore { get; set; }
+
+        [JsonProperty("versions")]
+        public List<string>? Versions { get; set; }
+    }
+}

--- a/UnityContext7Assistant/Packages/manifest.json
+++ b/UnityContext7Assistant/Packages/manifest.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "com.unity.nuget.newtonsoft-json": "3.2.1"
+  }
+}

--- a/UnityContext7Assistant/README.md
+++ b/UnityContext7Assistant/README.md
@@ -1,0 +1,73 @@
+# Blaze Intelligence Context7 Unity Assistant
+
+This Unity Editor extension integrates the [Context7](https://github.com/upstash/context7) documentation service directly into the Unity workflow. It lets Blaze Intelligence developers query real-time library documentation, browse search results, and pull contextual code snippets without leaving the editor.
+
+## Features
+
+- 🔍 Search any npm or package registry entry supported by Context7.
+- 📄 Stream the latest documentation/context for the selected library.
+- 🔁 Quickly refresh snippets as you iterate on Unity scripts.
+- 🔐 Keeps API keys outside the project by using environment variables.
+
+## Project Layout
+
+```
+UnityContext7Assistant/
+├── Assets/
+│   └── Editor/
+│       ├── Context7ApiClient.cs
+│       ├── Context7AssistantWindow.cs
+│       └── Context7Models.cs
+└── Packages/
+    └── manifest.json
+```
+
+Add this folder to an existing Unity project or open it standalone to bootstrap a new workspace.
+
+## Prerequisites
+
+1. Unity 2021.3 LTS or newer (required for the async/await capable UnityWebRequest API).
+2. A Context7 API key from [context7.com](https://context7.com). Keys should look like `ctx7sk_...`.
+3. macOS, Windows, or Linux editor with outbound HTTPS access to `https://context7.com`.
+
+## Setup
+
+1. Copy the `UnityContext7Assistant` directory into your Unity project root.
+2. Ensure the Newtonsoft JSON package installs (Unity will import `com.unity.nuget.newtonsoft-json@3.2.1` automatically on open).
+3. Provide credentials securely:
+   - Set `CONTEXT7_API_KEY` in your shell or CI environment. **Do not** commit keys to source control.
+   - (Optional) Set `CONTEXT7_CLIENT_IP` if you want to forward a static IP for rate limiting purposes.
+4. Launch Unity. The editor scripts compile automatically.
+5. Open the window via **Blaze Intelligence ▸ Context7 Assistant**.
+
+## Using the Assistant
+
+1. Enter a search query (for example: `Unity Addressables`).
+2. Select a result to load tokens and documentation.
+3. Adjust the token budget or topic filter to focus on specific areas (e.g., `async loading`).
+4. Copy library identifiers into your prompts or Unity code as needed.
+
+The window caches non-sensitive preferences (API base URL, token budget, topic filter) via `EditorPrefs`. Secrets remain in memory only.
+
+## Troubleshooting
+
+- **401 Unauthorized** – verify the API key is present and valid.
+- **429 Rate Limited** – Context7 throttles aggressive usage; try again later or reduce automation frequency.
+- **Empty results** – confirm the package exists or broaden your search query.
+
+## Extending the Integration
+
+- Hook the `Context7ApiClient` into custom editor tools or inspectors to surface targeted docs inline.
+- Persist workspace-specific defaults via scriptable objects if you need project-level overrides.
+- Add structured logging or analytics by wrapping the `Context7ApiClient` calls (ensure no secrets are logged).
+
+## Security Notes
+
+- Keep API keys out of version control—use environment variables or Unity Cloud Build secrets.
+- UnityWebRequest transmits over HTTPS only; no plaintext transport is used.
+- Consider proxy configuration if your network requires outbound filtering.
+
+## Testing Strategy
+
+Unity editor scripts rely on manual verification. For automated coverage, create Edit Mode tests that mock `UnityWebRequest` using `UnityEngine.TestTools` and assert parsing/formatting logic.
+


### PR DESCRIPTION
## Summary
- add a Unity Editor window that connects to Context7 to search libraries and pull documentation
- create a lightweight API client and models for Context7 REST endpoints
- document setup and usage for the Blaze Intelligence Context7 Unity assistant

## Testing
- not run (Unity editor tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d9899da2f88330acf3ef083a158cf5